### PR TITLE
feat(677): first implementation of command-validator

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,2 @@
+node_modules/
+artifacts/

--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -1,0 +1,1 @@
+extends: screwdriver

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+node_modules/
+artifacts/
+npm-debug.log
+.DS_STORE
+.*.swp
+.idea/
+.nyc_output/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,3 @@
+# Contributing to Screwdriver
+
+Have a look at our guidelines, as well as pointers on where to start making changes, in our official [documentation](http://docs.screwdriver.cd/about/contributing).

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,24 @@
+Copyright 2017 Yahoo Inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the Yahoo! Inc. nor the
+      names of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL YAHOO! INC. BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ habitat:
 
 ## Usage
 
-
 ```bash
 $ npm install screwdriver-command-validator
 ```
@@ -55,6 +54,23 @@ config: {
         command: 'git clone'
     }
 }
+```
+
+Validate in CLI:
+```bash
+$ ./node_modules/.bin/command-validate -h
+
+  Usage: validate [options]
+
+
+  Options:
+
+    -j, --json         output with JSON
+    -f, --file [name]  screwdriver command file (default: ./sd-command.yaml)
+    -h, --help         output usage information
+
+$ ./node_modules/.bin/command-validate -j
+{"valid":true}
 ```
 
 ## Testing

--- a/README.md
+++ b/README.md
@@ -1,1 +1,79 @@
 # command-validator
+[![Version][npm-image]][npm-url] ![Downloads][downloads-image] [![Build Status][status-image]][status-url] [![Open Issues][issues-image]][issues-url] [![Dependency Status][daviddm-image]][daviddm-url] ![License][license-image]
+
+> A module for validating a Screwdriver Command file
+
+## yaml
+
+```yaml
+# example.yaml
+namespace: git
+command: clone
+version: '1.0'
+description: SD Command for git clone with habitat.
+maintainer: example@gmail.com
+format: habitat
+habitat:
+    mode: remote
+    package: core/git/2.14.1
+    command:  git clone
+```
+
+## Usage
+
+
+```bash
+$ npm install screwdriver-command-validator
+```
+
+Validate in Node.js:
+
+```javascript
+const fs = require('fs');  // standard fs module
+const validator = require('screwdriver-command-validator');
+
+// The "example.yaml" is the YAML described above
+validator(fs.readFileSync('example.yaml'))
+    .then((commandData) => {
+        console.log(commandData);
+    });
+```
+
+Output of the console.log():
+
+```javascript
+config: {
+    description: 'SD Command for git clone with habitat.',
+    maintainer: 'example@gmail.com',
+    command: 'git',
+    namespace: 'clone',
+    version: '1.0',
+    format: 'habitat',
+    habitat: {
+        mode: 'remote',
+        package: 'core/git/2.14.1',
+        command: 'git clone'
+    }
+}
+```
+
+## Testing
+
+```bash
+npm test
+```
+
+## License
+
+Code licensed under the BSD 3-Clause license. See LICENSE file for terms.
+
+[npm-image]: https://img.shields.io/npm/v/screwdriver-command-validator.svg
+[npm-url]: https://npmjs.org/package/screwdriver-command-validator
+[downloads-image]: https://img.shields.io/npm/dt/screwdriver-command-validator.svg
+[license-image]: https://img.shields.io/npm/l/screwdriver-command-validator.svg
+[issues-image]: https://img.shields.io/github/issues/screwdriver-cd/command-validator.svg
+[issues-url]: https://github.com/screwdriver-cd/command-validator/issues
+[status-image]: https://cd.screwdriver.cd/pipelines/410/badge
+[status-url]: https://cd.screwdriver.cd/pipelines/410
+[daviddm-image]: https://david-dm.org/screwdriver-cd/command-validator.svg?theme=shields.io
+[daviddm-url]: https://david-dm.org/screwdriver-cd/command-validator

--- a/index.js
+++ b/index.js
@@ -1,0 +1,62 @@
+'use strict';
+
+const Joi = require('joi');
+const SCHEMA_CONFIG = require('screwdriver-data-schema').config.command.schemaCommand;
+const Yaml = require('js-yaml');
+
+/**
+ * Loads the configuration from a stringified sd-command.yaml
+ * @method loadCommandSpecYaml
+ * @param  {String} yamlString Contents of sd-command.yaml
+ * @return {Promise}           Promise that resolves to the command as a config object
+ */
+function loadCommandSpecYaml(yamlString) {
+    return new Promise(resolve => resolve(Yaml.safeLoad(yamlString)));
+}
+
+/**
+ * Validate the command configuration
+ * @method validateCommand
+ * @param  {Object}         commandObj  Configuration object that represents the command
+ * @return {Promise}                    Promise that resolves to the passed-in config object
+ */
+function validateCommand(commandObj) {
+    return new Promise((resolve, reject) => {
+        Joi.validate(commandObj, SCHEMA_CONFIG, {
+            abortEarly: false
+        }, (err, data) => {
+            if (err) {
+                return reject(err);
+            }
+
+            return resolve(data);
+        });
+    });
+}
+
+/**
+ * Parses the configuration from a screwdriver-command-spec.yaml
+ * @method parseCommand
+ * @param  {String} yamlString Contents of screwdriver-command-spec.yaml
+ * @return {Promise}           Promise that rejects if the configuration cannot be parsed
+ *                             The promise will eventually resolve into:
+ *         {Object}   config
+ *         {Object}   config.command   The parsed command that was validated
+ *         {Object[]} config.errors    An array of objects related to validating
+ *                                     the given command
+ */
+function parseCommand(yamlString) {
+    return loadCommandSpecYaml(yamlString)
+        .then(configToValidate =>
+            validateCommand(configToValidate)
+                .then(commandConfiguration => ({
+                    errors: [],
+                    config: commandConfiguration
+                }), err => ({
+                    errors: err.details,
+                    config: configToValidate
+                }))
+        );
+}
+
+module.exports = parseCommand;

--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ function validateCommand(commandObj) {
 /**
  * Parses the configuration from a screwdriver-command-spec.yaml
  * @method parseCommand
- * @param  {String} yamlString Contents of screwdriver-command-spec.yaml
+ * @param  {String} yamlString Contents of screwdriver command yaml
  * @return {Promise}           Promise that rejects if the configuration cannot be parsed
  *                             The promise will eventually resolve into:
  *         {Object}   config

--- a/package.json
+++ b/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "screwdriver-command-validator",
+  "version": "1.0.0",
+  "description": "A module for validating a Screwdriver Command file",
+  "main": "index.js",
+  "scripts": {
+    "pretest": "eslint .",
+    "test": "jenkins-mocha --recursive",
+    "semantic-release": "semantic-release pre && npm publish && semantic-release post"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:screwdriver-cd/command-validator.git"
+  },
+  "homepage": "https://github.com/screwdriver-cd/command-validator",
+  "bugs": "https://github.com/screwdriver-cd/screwdriver/issues",
+  "keywords": [
+    "screwdriver",
+    "yahoo"
+  ],
+  "license": "BSD-3-Clause",
+  "author": "Hiroki Takatsuka <tktk.stereoman@gmail.com>",
+  "contributors": [
+    "Dao Lam <daolam112@gmail.com>",
+    "Darren Matsumoto <aeneascorrupt@gmail.com>",
+    "Jeremiah Wuenschel <jeremiah.wuenschel@gmail.com>",
+    "Min Zhang <minzhang@andrew.cmu.edu>",
+    "Peter Peterson <jedipetey@gmail.com>",
+    "St. John Johnson <st.john.johnson@gmail.com",
+    "Tiffany Kyi <tiffanykyi@gmail.com>"
+  ],
+  "devDependencies": {
+    "chai": "^3.5.0",
+    "eslint": "^4.3.0",
+    "eslint-config-screwdriver": "^3.0.0",
+    "hoek": "^4.1.0",
+    "jenkins-mocha": "^6.0.0"
+  },
+  "dependencies": {
+    "joi": "^10.6.0",
+    "js-yaml": "^3.8.1",
+    "screwdriver-data-schema": "^18.9.0"
+  },
+  "release": {
+    "debug": false,
+    "verifyConditions": {
+      "path": "./node_modules/semantic-release/src/lib/plugin-noop.js"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
     "type": "git",
     "url": "git@github.com:screwdriver-cd/command-validator.git"
   },
+  "bin": {
+    "command-validate": "./validate.js"
+  },
   "homepage": "https://github.com/screwdriver-cd/command-validator",
   "bugs": "https://github.com/screwdriver-cd/screwdriver/issues",
   "keywords": [
@@ -37,6 +40,7 @@
     "jenkins-mocha": "^6.0.0"
   },
   "dependencies": {
+    "commander": "^2.12.2",
     "joi": "^10.6.0",
     "js-yaml": "^3.8.1",
     "screwdriver-data-schema": "^18.9.0"

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "commander": "^2.12.2",
     "joi": "^10.6.0",
     "js-yaml": "^3.8.1",
-    "screwdriver-data-schema": "^18.9.0"
+    "screwdriver-data-schema": "^18.10.0"
   },
   "release": {
     "debug": false,

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -1,0 +1,17 @@
+shared:
+  image: node:6
+
+jobs:
+  main:
+    requires: [ ~pr, ~commit ]
+    steps:
+      - install: npm install
+      - test: npm test
+  publish:
+    requires: [ main ]
+    template: screwdriver-cd/semantic-release 
+    secrets:
+      # Publishing to NPM
+      - NPM_TOKEN
+      # Pushing tags to Git
+      - GH_TOKEN

--- a/test/.eslintrc.yaml
+++ b/test/.eslintrc.yaml
@@ -1,0 +1,4 @@
+extends: screwdriver
+rules:
+    func-names: off
+    prefer-arrow-callback: off

--- a/test/data/bad_structure_command.yaml
+++ b/test/data/bad_structure_command.yaml
@@ -1,0 +1,9 @@
+namespace: foo
+command: bar
+version: '1.0'
+maintainer: foo@bar.com
+format: docker
+habitat:
+  mode: remote
+  package: core/git
+  binary: git

--- a/test/data/bad_structure_command.yaml
+++ b/test/data/bad_structure_command.yaml
@@ -6,4 +6,4 @@ format: docker
 habitat:
   mode: remote
   package: core/git
-  binary: git
+  command: git

--- a/test/data/valid_binary_command_spec.yaml
+++ b/test/data/valid_binary_command_spec.yaml
@@ -1,0 +1,8 @@
+namespace: foo
+command: bar
+version: '1.0'
+description: this is sd-command of binary
+maintainer: foo@bar.com
+format: binary
+binary:
+  file: ./foobar.sh

--- a/test/data/valid_docker_command_spec.yaml
+++ b/test/data/valid_docker_command_spec.yaml
@@ -1,0 +1,9 @@
+namespace: foo
+command: bar
+version: '1.0'
+description: this is sd-command of docker
+maintainer: foo@bar.com
+format: docker
+docker:
+  image: node:6
+  command: node

--- a/test/data/valid_habitat_command_spec.yaml
+++ b/test/data/valid_habitat_command_spec.yaml
@@ -1,0 +1,10 @@
+namespace: foo
+command: bar
+version: '1.0'
+description: this is sd-command of habitat
+maintainer: foo@bar.com
+format: habitat
+habitat:
+    mode: remote
+    package: core/git/2.14.1
+    command:  git

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,0 +1,132 @@
+'use strict';
+
+const assert = require('chai').assert;
+const fs = require('fs');
+const hoek = require('hoek');
+const path = require('path');
+const validator = require('../index.js');
+
+const TEST_YAML_FOLDER = path.resolve(__dirname, 'data');
+const BINARY_COMMAND_PATH = path.resolve(TEST_YAML_FOLDER, 'valid_binary_command_spec.yaml');
+const DOCKER_COMMAND_PATH = path.resolve(TEST_YAML_FOLDER, 'valid_docker_command_spec.yaml');
+const HABITAT_COMMAND_PATH = path.resolve(TEST_YAML_FOLDER, 'valid_habitat_command_spec.yaml');
+const BAD_STRUCTURE_COMMAND_PATH = path.resolve(TEST_YAML_FOLDER, 'bad_structure_command.yaml');
+
+describe('index test', () => {
+    it('parses a valid binary command yaml', () => {
+        const yamlString = fs.readFileSync(BINARY_COMMAND_PATH);
+
+        return validator(yamlString)
+            .then((config) => {
+                assert.isObject(config);
+
+                assert.deepEqual(config, {
+                    errors: [],
+                    config: {
+                        description: 'this is sd-command of binary',
+                        maintainer: 'foo@bar.com',
+                        command: 'bar',
+                        namespace: 'foo',
+                        version: '1.0',
+                        format: 'binary',
+                        binary: {
+                            file: './foobar.sh'
+                        }
+                    }
+                });
+            });
+    });
+
+    it('parses a valid docker command yaml', () => {
+        const yamlString = fs.readFileSync(DOCKER_COMMAND_PATH);
+
+        return validator(yamlString)
+            .then((config) => {
+                assert.isObject(config);
+
+                assert.deepEqual(config, {
+                    errors: [],
+                    config: {
+                        description: 'this is sd-command of docker',
+                        maintainer: 'foo@bar.com',
+                        command: 'bar',
+                        namespace: 'foo',
+                        version: '1.0',
+                        format: 'docker',
+                        docker: {
+                            image: 'node:6',
+                            command: 'node'
+                        }
+                    }
+                });
+            });
+    });
+
+    it('parses a valid habitat command yaml', () => {
+        const yamlString = fs.readFileSync(HABITAT_COMMAND_PATH);
+
+        return validator(yamlString)
+            .then((config) => {
+                assert.isObject(config);
+
+                assert.deepEqual(config, {
+                    errors: [],
+                    config: {
+                        description: 'this is sd-command of habitat',
+                        maintainer: 'foo@bar.com',
+                        command: 'bar',
+                        namespace: 'foo',
+                        version: '1.0',
+                        format: 'habitat',
+                        habitat: {
+                            mode: 'remote',
+                            package: 'core/git/2.14.1',
+                            command: 'git'
+                        }
+                    }
+                });
+            });
+    });
+
+    it('validates a poorly structured command yaml', () => {
+        const yamlString = fs.readFileSync(BAD_STRUCTURE_COMMAND_PATH);
+
+        return validator(yamlString)
+            .then((result) => {
+                assert.deepEqual(result.config, {
+                    maintainer: 'foo@bar.com',
+                    command: 'bar',
+                    namespace: 'foo',
+                    version: '1.0',
+                    format: 'docker',
+                    habitat: {
+                        mode: 'remote',
+                        package: 'core/git',
+                        command: 'git'
+                    }
+                });
+                assert.strictEqual(result.errors.length, 2);
+
+                // check required description
+                const missingField = hoek.reach(result.config, result.errors[0].path);
+
+                assert.strictEqual(result.errors[0].message, '"description" is required');
+                assert.isUndefined(missingField);
+
+                // check required docker specified in format
+                const missingField2 = hoek.reach(result.config, result.errors[1].path);
+
+                assert.strictEqual(result.errors[1].message, '"docker" is required');
+                assert.isUndefined(missingField2);
+            }, assert.fail);
+    });
+
+    it('throws when parsing incorrectly formatted yaml', () => {
+        const yamlString = 'main: :';
+
+        return validator(yamlString)
+            .then(assert.fail, (err) => {
+                assert.match(err, /YAMLException/);
+            });
+    });
+});

--- a/validate.js
+++ b/validate.js
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+
+'use strict';
+
+const index = require('./index');
+const commander = require('commander');
+const fs = require('fs');
+
+commander
+    .usage('[options]')
+    .option('-j, --json', 'output with JSON')
+    .option('-f, --file [path]', 'screwdriver command file', './sd-command.yaml')
+    .parse(process.argv);
+
+/**
+ * Loads the yaml configuration from a file
+ * @method loadFile
+ * @param  {String}     path        File path
+ * @return {Promise}    Promise that resolves to the command as a yaml string
+ */
+function loadFile(path) {
+    return new Promise(resolve =>
+        resolve(fs.readFileSync(path, 'utf8')));
+}
+
+return loadFile(commander.file)
+    .then(yamlString => index(yamlString))
+    .then((result) => {
+        if (result.errors.length > 0) {
+            console.error(result.errors);
+            process.exit(1);
+        } else if (commander.json) {
+            console.log(JSON.stringify({ valid: true }));
+        } else {
+            console.log('true');
+        }
+    })
+    .catch((err) => {
+        console.error(err);
+        process.exit(1);
+    });


### PR DESCRIPTION
## Context
We need validation package for implementing command feature.

## Objective
This PR provides a command validator package. Like [template-valudator](https://github.com/screwdriver-cd/template-validator).

## References
- [sd-command  design doc](https://github.com/screwdriver-cd/screwdriver/blob/master/design/commands.md)
- [x] Blocked by https://github.com/screwdriver-cd/data-schema/pull/195
- Need some more fix:
    - [x] URLs of README
    - [x] data-schema version