### PR TITLE
fix: fix schema to command from config

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,10 +51,10 @@ function parseCommand(yamlString) {
             validateCommand(configToValidate)
                 .then(commandConfiguration => ({
                     errors: [],
-                    config: commandConfiguration
+                    command: commandConfiguration
                 }), err => ({
                     errors: err.details,
-                    config: configToValidate
+                    command: configToValidate
                 }))
         );
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -108,13 +108,13 @@ describe('index test', () => {
                 assert.strictEqual(result.errors.length, 2);
 
                 // check required description
-                const missingField = hoek.reach(result.config, result.errors[0].path);
+                const missingField = hoek.reach(result.command, result.errors[0].path);
 
                 assert.strictEqual(result.errors[0].message, '"description" is required');
                 assert.isUndefined(missingField);
 
                 // check required docker specified in format
-                const missingField2 = hoek.reach(result.config, result.errors[1].path);
+                const missingField2 = hoek.reach(result.command, result.errors[1].path);
 
                 assert.strictEqual(result.errors[1].message, '"docker" is required');
                 assert.isUndefined(missingField2);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -22,7 +22,7 @@ describe('index test', () => {
 
                 assert.deepEqual(config, {
                     errors: [],
-                    config: {
+                    command: {
                         description: 'this is sd-command of binary',
                         maintainer: 'foo@bar.com',
                         name: 'bar',
@@ -46,7 +46,7 @@ describe('index test', () => {
 
                 assert.deepEqual(config, {
                     errors: [],
-                    config: {
+                    command: {
                         description: 'this is sd-command of docker',
                         maintainer: 'foo@bar.com',
                         name: 'bar',
@@ -71,7 +71,7 @@ describe('index test', () => {
 
                 assert.deepEqual(config, {
                     errors: [],
-                    config: {
+                    command: {
                         description: 'this is sd-command of habitat',
                         maintainer: 'foo@bar.com',
                         name: 'bar',
@@ -93,7 +93,7 @@ describe('index test', () => {
 
         return validator(yamlString)
             .then((result) => {
-                assert.deepEqual(result.config, {
+                assert.deepEqual(result.command, {
                     maintainer: 'foo@bar.com',
                     name: 'bar',
                     namespace: 'foo',


### PR DESCRIPTION
"command.command" problem is solved. This PR fixes json schema to "command" from "config" same with [template-validator](https://github.com/screwdriver-cd/template-validator/blob/bf61199cd9eb66d732ab83410adf5f5f7a22f070/index.js#L56).

Related: https://github.com/screwdriver-cd/screwdriver/pull/829