### PR TITLE
fix(hip): Upgrade to node:8

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,27 +36,29 @@ function validateCommand(commandObj) {
 
 /**
  * Parses the configuration from a screwdriver-command-spec.yaml
- * @method parseCommand
- * @param  {String} yamlString Contents of screwdriver command yaml
- * @return {Promise}           Promise that rejects if the configuration cannot be parsed
- *                             The promise will eventually resolve into:
+ * @async  parseCommand
+ * @param  {String}  yamlString Contents of screwdriver command yaml
+ * @return {Promise}            Promise that rejects if the configuration cannot be parsed
+ *                              The promise will eventually resolve into:
  *         {Object}   config
  *         {Object}   config.command   The parsed command that was validated
  *         {Object[]} config.errors    An array of objects related to validating
  *                                     the given command
  */
-function parseCommand(yamlString) {
-    return loadCommandSpecYaml(yamlString)
-        .then(configToValidate =>
-            validateCommand(configToValidate)
-                .then(commandConfiguration => ({
-                    errors: [],
-                    command: commandConfiguration
-                }), err => ({
-                    errors: err.details,
-                    command: configToValidate
-                }))
-        );
+async function parseCommand(yamlString) {
+    const command = await loadCommandSpecYaml(yamlString);
+
+    try {
+        return {
+            errors: [],
+            command: await validateCommand(command)
+        };
+    } catch (err) {
+        return {
+            errors: err.details,
+            command
+        };
+    }
 }
 
 module.exports = parseCommand;

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "Jeremiah Wuenschel <jeremiah.wuenschel@gmail.com>",
     "Min Zhang <minzhang@andrew.cmu.edu>",
     "Peter Peterson <jedipetey@gmail.com>",
+    "Philip Scott <pscott@zeptohost.com>",
     "St. John Johnson <st.john.johnson@gmail.com",
     "Tiffany Kyi <tiffanykyi@gmail.com>"
   ],

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -1,5 +1,5 @@
 shared:
-  image: node:6
+  image: node:8
 
 jobs:
   main:
@@ -9,7 +9,7 @@ jobs:
       - test: npm test
   publish:
     requires: [ main ]
-    template: screwdriver-cd/semantic-release 
+    template: screwdriver-cd/semantic-release
     secrets:
       # Publishing to NPM
       - NPM_TOKEN


### PR DESCRIPTION
## Context

Node.js 6 is slowly becoming deprecated, with popular packages such as `semantic-release` no longer supporting it. Aside from maintenance, upgrading to Node.js 8 also provides async functions, which simplify `Promise` control flow.

## Objective

* Change image in `screwdriver.yaml` to `node:8`

#### Additional changes

* Refactor `parseCommand` to be an `async` function