### PR TITLE
feat(1958): Upgrade to @hapi/hapi v19.x.x. BREAKING CHANGE: pull joi v17

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const Joi = require('joi');
 const SCHEMA_CONFIG = require('screwdriver-data-schema').config.command.schemaCommand;
 const Yaml = require('js-yaml');
 
@@ -20,18 +19,14 @@ function loadCommandSpecYaml(yamlString) {
  * @param  {Object}         commandObj  Configuration object that represents the command
  * @return {Promise}                    Promise that resolves to the passed-in config object
  */
-function validateCommand(commandObj) {
-    return new Promise((resolve, reject) => {
-        Joi.validate(commandObj, SCHEMA_CONFIG, {
+async function validateCommand(commandObj) {
+    try {
+        return await SCHEMA_CONFIG.validateAsync(commandObj, {
             abortEarly: false
-        }, (err, data) => {
-            if (err) {
-                return reject(err);
-            }
-
-            return resolve(data);
         });
-    });
+    } catch (err) {
+        throw err;
+    }
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "screwdriver-command-validator",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "A module for validating a Screwdriver Command file",
   "main": "index.js",
   "scripts": {
     "pretest": "eslint .",
-    "test": "jenkins-mocha --recursive",
+    "test": "mocha --recursive",
     "semantic-release": "semantic-release pre && npm publish && semantic-release post"
   },
   "repository": {
@@ -34,17 +34,17 @@
     "Tiffany Kyi <tiffanykyi@gmail.com>"
   ],
   "devDependencies": {
+    "@hapi/hoek": "^9.0.4",
     "chai": "^3.5.0",
     "eslint": "^4.3.0",
     "eslint-config-screwdriver": "^3.0.0",
-    "hoek": "^4.1.0",
-    "jenkins-mocha": "^6.0.0"
+    "mocha": "^8.1.1"
   },
   "dependencies": {
     "commander": "^2.12.2",
-    "joi": "^13.0.0",
+    "joi": "^17.2.0",
     "js-yaml": "^3.8.1",
-    "screwdriver-data-schema": "^19.1.1"
+    "screwdriver-data-schema": "git://github.com/screwdriver-cd/data-schema.git#hapi-v19"
   },
   "release": {
     "debug": false,

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "commander": "^2.12.2",
     "joi": "^17.2.0",
     "js-yaml": "^3.8.1",
-    "screwdriver-data-schema": "git://github.com/screwdriver-cd/data-schema.git#hapi-v19"
+    "screwdriver-data-schema": "^20.0.0"
   },
   "release": {
     "debug": false,

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -1,5 +1,5 @@
 shared:
-  image: node:8
+  image: node:12
 
 jobs:
   main:

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -2,7 +2,7 @@
 
 const assert = require('chai').assert;
 const fs = require('fs');
-const hoek = require('hoek');
+const hoek = require('@hapi/hoek');
 const path = require('path');
 const validator = require('../index.js');
 


### PR DESCRIPTION
## Context

Screwdriver hapi.js dependencies are outdated and not supported anymore.

## Objective

This PR majorly upgrades joi version

## References

https://github.com/screwdriver-cd/screwdriver/issues/1958

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
